### PR TITLE
Support NamiCampaignManager.refresh

### DIFF
--- a/sdk/android/src/main/kotlin/com/namiml/flutter/sdk/FlutterNamiSdkPlugin.kt
+++ b/sdk/android/src/main/kotlin/com/namiml/flutter/sdk/FlutterNamiSdkPlugin.kt
@@ -310,6 +310,11 @@ class FlutterNamiSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     NamiCampaignManager.allCampaigns().map { it.convertToMap() }
                 )
             }
+            "campaigns.refresh" -> {
+                NamiCampaignManager.refresh { campaigns ->
+                    result.success(campaigns?.map { it.convertToMap() })
+                }
+            }
             "dismiss" -> {
                 result.notImplemented()
             }

--- a/sdk/ios/Classes/SwiftFlutterNamiSdkPlugin.swift
+++ b/sdk/ios/Classes/SwiftFlutterNamiSdkPlugin.swift
@@ -85,6 +85,13 @@ public class SwiftFlutterNamiSdkPlugin: NSObject, FlutterPlugin {
             let allCampaigns = NamiCampaignManager.allCampaigns()
             let listOfMaps = allCampaigns.map({ (campaign: NamiCampaign) in campaign.convertToMap()})
             result(listOfMaps)
+            
+        case "campaigns.refresh":
+            NamiCampaignManager.refresh{(campaigns: [NamiCampaign]) in
+                let listOfMaps = campaigns.map({ (campaign: NamiCampaign) in campaign.convertToMap()})
+                result(listOfMaps)
+            }
+            
         case "dismiss":
             let animated = call.arguments as? Bool ?? false
             NamiPaywallManager.dismiss(animated: animated) {

--- a/sdk/lib/campaign/nami_campaign_manager.dart
+++ b/sdk/lib/campaign/nami_campaign_manager.dart
@@ -37,6 +37,15 @@ class NamiCampaignManager {
     return data;
   }
 
+  /**
+   * Asks Nami to fetch the latest active campaigns for this device
+   * @return list of active campaigns after updating.
+   */
+  static Future<List<NamiCampaign>> refresh() async {
+    List<dynamic> list = await channel.invokeMethod("campaigns.refresh");
+    return list.map((e) => NamiCampaign.fromMap(e)).toList();
+  }
+
   static List<NamiCampaign> _mapToNamiCampaignList(List<dynamic> list) {
     return list.map((element) {
       return NamiCampaign.fromMap(element);


### PR DESCRIPTION
- Asks Nami to fetch the latest active campaigns for this device
- Return list of active campaigns after updating