### PR TITLE
NamiSku: Pass enum value for NamiSkuType

### DIFF
--- a/sdk/lib/paywall/nami_sku.dart
+++ b/sdk/lib/paywall/nami_sku.dart
@@ -24,7 +24,7 @@ class NamiSKU {
     return <String, dynamic>{
       "name": name,
       "skuId": skuId,
-      'type': type,
+      'type': type._toNamiSKUTypeName(),
       'id': id
     };
   }
@@ -48,6 +48,18 @@ extension on String? {
       return NamiSKUType.subscription;
     } else {
       return NamiSKUType.unknown;
+    }
+  }
+}
+
+extension on NamiSKUType? {
+  String _toNamiSKUTypeName() {
+    if (this == NamiSKUType.one_time_purchase) {
+      return "one_time_purchase";
+    } else if (this == NamiSKUType.subscription) {
+      return "subscription";
+    } else {
+      return "unknown";
     }
   }
 }


### PR DESCRIPTION
# Changelog

- I think removing` NamiSKUType.name` has broken the `buySkuComplete` flow.  As `name` property on `enum` is not available on the older versions that we support, I have added an additional method that returns value of the enum.

